### PR TITLE
Replace lodash per method packages with modular

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/index.js"
   ],
   "dependencies": {
-    "lodash.omit": "^4.5.0",
+    "lodash": "^4.17.4",
     "react": "^15.5.4"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import React from 'react';
-import omit from 'lodash/omit';
+import pickBy from 'lodash/pickBy';
 
 export default ({tag: defaultTag = 'div', prop = 'tag', propsToOmit = []} = {}) => {
   return ({children, ...otherProps}) => {
     const tag = otherProps[prop] || defaultTag;
-    const props = omit(otherProps, [prop, ...propsToOmit]);
+    const omitPropsKeys = [prop, ...propsToOmit];
+    const props = pickBy(otherProps, (value, key) => {
+      return omitPropsKeys.indexOf(key) === -1;
+    });
+
     return React.createElement(tag, props, children);
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import omit from 'lodash.omit';
+import omit from 'lodash/omit';
 
 export default ({tag: defaultTag = 'div', prop = 'tag', propsToOmit = []} = {}) => {
   return ({children, ...otherProps}) => {


### PR DESCRIPTION
Hi @jameslnewell

Noticed that it is still using method lodash package `.omit`.
It is going to be deprecated soon [https://github.com/lodash/lodash/wiki/Roadmap](https://github.com/lodash/lodash/wiki/Roadmap) and the modular way could save the bundled js size a bit.

Thanks for the lib!